### PR TITLE
Using the correct value for parameter 'notify'

### DIFF
--- a/src/Monolog/Handler/HipChatHandler.php
+++ b/src/Monolog/Handler/HipChatHandler.php
@@ -135,7 +135,9 @@ class HipChatHandler extends SocketHandler
     private function buildContent($record)
     {
         $dataArray = array(
-            'notify' => $this->notify,
+            'notify' => $this->version == self::API_V1 ?
+                ($this->notify ? 1 : 0) :
+                ($this->notify ? 'true' : 'false'),
             'message' => $record['formatted'],
             'message_format' => $this->format,
             'color' => $this->getAlertColor($record['level']),


### PR DESCRIPTION
Note that in [V1](https://www.hipchat.com/docs/api/method/rooms/message) the **notify** parameter is 0 or 1. On the other hand, [V2](https://www.hipchat.com/docs/apiv2/method/send_room_notification) uses strings "false" or "true"
